### PR TITLE
updating license to apache and file location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN dnf module -y install python39 && dnf install -y python39 python39-pip && dn
 
 RUN mkdir /stressng
 RUN chmod 777 /stressng
-ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugins/main/LICENSE /stressng/
+ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugin-template-python/main/LICENSE /stressng/
 ADD README.md /stressng/
 ADD stressng_plugin.py /stressng/
 ADD poetry.lock /stressng/
@@ -23,8 +23,8 @@ USER 1000
 ENTRYPOINT ["/stressng/stressng_plugin.py"]
 CMD []
 
-LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugins/tree/main/python/stressng"
-LABEL org.opencontainers.image.licenses="Apache-2.0+GPL-2.0-only"
+LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugin-stressng"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.vendor="Arcalot project"
 LABEL org.opencontainers.image.authors="Arcalot contributors"
 LABEL org.opencontainers.image.title="Arcaflow stress-ng workload plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "arcaflow-plugin-stressng"
 version = "0.1.0"
 description = "arcaflow plugin for stressng"
 authors = ["arcalot"]
-license = "Apache-2.0+GPL-2.0-only"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "stressng_plugin.py", from="."}]
 


### PR DESCRIPTION
## Changes introduced with this PR

Update license to Apache 2.0 oinly
Update file location of License to arcaflow-plugin-template-python
Updated plugin repo to correct URL address

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).