### PR TITLE
fixing schema bug on cleanup option wrong type

### DIFF
--- a/stressng_plugin.py
+++ b/stressng_plugin.py
@@ -210,7 +210,7 @@ class WorkloadParams:
     """
 
     StressNGParams: StressNGParams
-    cleanup: typing.Optional[bool] = "True"
+    cleanup: typing.Optional[bool] = True
 
 
 @dataclass


### PR DESCRIPTION
## Changes introduced with this PR

cleanup property in schema wrongly initialized with string value instead of bool (as declared in the schema).

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).