### PR TITLE
added python deployer `incompatible` capability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "arcaflow plugin for stressng"
 authors = ["arcalot"]
 license = "Apache-2.0+GPL-2.0-only"
 readme = "README.md"
+classifiers = ["Arcaflow :: Python Deployer :: Incompatible"]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
## Changes introduced with this PR

This change in the pyproject.toml will mark the plugin as incompatible with arcaflow-python-deployer. 
The deployer will run a `pip show --verbose <module_name>` and, if the flag has been added in the capabilities field, will be captured by the deployer that will abort the run (if security checks has not been overridden in the deployer config).
This module has been selected to be the first to adopt this convention because it requires a binary cli tool that is usually shipped together with the module in a prebuilt container. All the modules considered as `incompatible` with the python deployer will be configured in the same way when the python deployer will be merged.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).