### PR TITLE
Make management of stressors table-driven

### DIFF
--- a/arcaflow_plugin_stressng/stressng_plugin.py
+++ b/arcaflow_plugin_stressng/stressng_plugin.py
@@ -98,7 +98,9 @@ def stressng_run(
     metrics = stressng_yaml["metrics"]
 
     system_un = system_info_output_schema.unserialize(system_info)
-    un = {
+    # Unserialize the result from each metric and cache it keyed by the
+    # name of the stressor which generated it.
+    results = {
         m["stressor"]: stressor_schemas[m["stressor"]].unserialize(m) for m in metrics
     }
 
@@ -113,12 +115,12 @@ def stressng_run(
     return "success", WorkloadResults(
         test_config=params,
         systeminfo=system_un,
-        vminfo=un.get(Stressors.VM),
-        mmapinfo=un.get(Stressors.MMAP),
-        cpuinfo=un.get(Stressors.CPU),
-        matrixinfo=un.get(Stressors.MATRIX),
-        mqinfo=un.get(Stressors.MQ),
-        hddinfo=un.get(Stressors.HDD),
+        vminfo=results.get(Stressors.VM),
+        mmapinfo=results.get(Stressors.MMAP),
+        cpuinfo=results.get(Stressors.CPU),
+        matrixinfo=results.get(Stressors.MATRIX),
+        mqinfo=results.get(Stressors.MQ),
+        hddinfo=results.get(Stressors.HDD),
     )
 
 

--- a/arcaflow_plugin_stressng/stressng_plugin.py
+++ b/arcaflow_plugin_stressng/stressng_plugin.py
@@ -9,16 +9,12 @@ import yaml
 
 from arcaflow_plugin_sdk import plugin
 from stressng_schema import (
+    Stressors,
     StressNGParams,
     WorkloadResults,
     WorkloadError,
     system_info_output_schema,
-    cpu_output_schema,
-    vm_output_schema,
-    mmap_output_schema,
-    matrix_output_schema,
-    mq_output_schema,
-    hdd_output_schema,
+    stressor_schemas,
 )
 
 
@@ -101,28 +97,10 @@ def stressng_run(
     system_info = stressng_yaml["system-info"]
     metrics = stressng_yaml["metrics"]
 
-    # allocate all stressor information with None in case they don't get called
-    cpuinfo_un = None
-    vminfo_un = None
-    mmapinfo_un = None
-    matrixinfo_un = None
-    mqinfo_un = None
-    hddinfo_un = None
-
     system_un = system_info_output_schema.unserialize(system_info)
-    for metric in metrics:
-        if metric["stressor"] == "cpu":
-            cpuinfo_un = cpu_output_schema.unserialize(metric)
-        if metric["stressor"] == "vm":
-            vminfo_un = vm_output_schema.unserialize(metric)
-        if metric["stressor"] == "mmap":
-            mmapinfo_un = mmap_output_schema.unserialize(metric)
-        if metric["stressor"] == "matrix":
-            matrixinfo_un = matrix_output_schema.unserialize(metric)
-        if metric["stressor"] == "mq":
-            mqinfo_un = mq_output_schema.unserialize(metric)
-        if metric["stressor"] == "hdd":
-            hddinfo_un = hdd_output_schema.unserialize(metric)
+    un = {
+        m["stressor"]: stressor_schemas[m["stressor"]].unserialize(m) for m in metrics
+    }
 
     print("==>> Workload run complete!")
     os.close(stressng_jobfile[0])
@@ -133,14 +111,14 @@ def stressng_run(
         os.remove(stressng_jobfile[1])
 
     return "success", WorkloadResults(
-        params,
-        system_un,
-        vminfo_un,
-        mmapinfo_un,
-        cpuinfo_un,
-        matrixinfo_un,
-        mqinfo_un,
-        hddinfo_un,
+        test_config=params,
+        systeminfo=system_un,
+        vminfo=un.get(Stressors.VM),
+        mmapinfo=un.get(Stressors.MMAP),
+        cpuinfo=un.get(Stressors.CPU),
+        matrixinfo=un.get(Stressors.MATRIX),
+        mqinfo=un.get(Stressors.MQ),
+        hddinfo=un.get(Stressors.HDD),
     )
 
 

--- a/arcaflow_plugin_stressng/stressng_schema.py
+++ b/arcaflow_plugin_stressng/stressng_schema.py
@@ -32,6 +32,11 @@ class Stressors(str, enum.Enum):
     IOMIX = "iomix"
 
 
+# Mapping of Stressors to their corresponding output schemas (each schema
+# definition is added as it is defined, below).
+stressor_schemas = {}
+
+
 class CpuMethod(str, enum.Enum):
     ALL = "all"
     ACKERMANN = "ackermann"
@@ -918,7 +923,7 @@ class VMOutput(CommonOutput):
     """
 
 
-vm_output_schema = plugin.build_object_schema(VMOutput)
+stressor_schemas[Stressors.VM] = plugin.build_object_schema(VMOutput)
 
 
 @dataclass
@@ -928,7 +933,7 @@ class MmapOutput(CommonOutput):
     """
 
 
-mmap_output_schema = plugin.build_object_schema(MmapOutput)
+stressor_schemas[Stressors.MMAP] = plugin.build_object_schema(MmapOutput)
 
 
 @dataclass
@@ -938,7 +943,7 @@ class CPUOutput(CommonOutput):
     """
 
 
-cpu_output_schema = plugin.build_object_schema(CPUOutput)
+stressor_schemas[Stressors.CPU] = plugin.build_object_schema(CPUOutput)
 
 
 @dataclass
@@ -1032,7 +1037,7 @@ class MatrixOutput(CommonOutput):
     ] = None
 
 
-matrix_output_schema = plugin.build_object_schema(MatrixOutput)
+stressor_schemas[Stressors.MATRIX] = plugin.build_object_schema(MatrixOutput)
 
 
 @dataclass
@@ -1042,7 +1047,7 @@ class MQOutput(CommonOutput):
     """
 
 
-mq_output_schema = plugin.build_object_schema(MQOutput)
+stressor_schemas[Stressors.MQ] = plugin.build_object_schema(MQOutput)
 
 
 @dataclass
@@ -1070,7 +1075,7 @@ class HDDOutput(CommonOutput):
     ]
 
 
-hdd_output_schema = plugin.build_object_schema(HDDOutput)
+stressor_schemas[Stressors.HDD] = plugin.build_object_schema(HDDOutput)
 
 
 @dataclass


### PR DESCRIPTION
## Changes introduced with this PR

This PR modifies the plugin to manage the stressors via a table which reduces the amount of code required.

_\[This was originally presented in https://github.com/pviladegut/arcaflow-plugin-stressng/pull/1 , but, per [Dustin's suggestion](https://github.com/arcalot/arcaflow-plugin-stressng/pull/41#issuecomment-2145991912), we are splitting it off and applying it ahead of https://github.com/arcalot/arcaflow-plugin-stressng/pull/41 , so that the changes introduced in that PR will be simpler.]_

CC: @pviladegut

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).